### PR TITLE
Use $TMPDIR (instead of assuming /tmp).

### DIFF
--- a/ftdetect/arcanist.vim
+++ b/ftdetect/arcanist.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead /tmp/*/new-commit setlocal filetype=arcanistdiff
+au BufNewFile,BufRead $TMPDIR/*/new-commit setlocal filetype=arcanistdiff


### PR DESCRIPTION
On Mac OS X, for example, temporary files live under /var/private.

Using $TMPDIR should do the right thing here for all platforms, assuming it's
important that we only match 'new-commit' files within a temporary directory
and not globally.