### PR TITLE
Fix $TMPDIR test and expansion.

### DIFF
--- a/ftdetect/arcanist.vim
+++ b/ftdetect/arcanist.vim
@@ -1,5 +1,5 @@
-if empty($TMPDIR)
-    let s:tmp = $TMPDIR
+if !empty($TMPDIR)
+    let s:tmp = "$TMPDIR"
 else
     let s:tmp = '/tmp'
 endif


### PR DESCRIPTION
We want to use $TMPDIR when its non-empty.  Also, wrap $TMPDIR in a string to
expand its value before assigning to s:tmp.