### PR TITLE
Generalize "heading" syntax matching.

### DIFF
--- a/syntax/arcanistdiff.vim
+++ b/syntax/arcanistdiff.vim
@@ -2,10 +2,7 @@ if has('spell')
     syn spell toplevel
 endif
 
-syn match arcanistdiffSummary "^Summary:"
-syn match arcanistdiffTestPlan "^Test Plan:"
-syn match arcanistdiffReviewers "^Reviewers:"
-syn match arcanistdiffSubscribers "^Subscribers:"
+syn match   arcanistdiffHeading "^\(\u\S\+\s*\)\+:"
 syn match   arcanistdiffComment "^#.*"
 
 " The first line should only span one line.
@@ -17,11 +14,7 @@ syn match   arcanistdiffSimpleSummary   "^.\{0,50\}"
 syn match   arcanistdiffOverflow    ".*" contained contains=@Spell
 syn match   arcanistdiffBlank   "^[^#].*" contained contains=@Spell
 
-hi def link arcanistdiffSummary Special
-hi def link arcanistdiffTestPlan Special
-hi def link arcanistdiffReviewers Special
-hi def link arcanistdiffSubscribers Special
-
 hi def link arcanistdiffSimpleSummary Keyword
 hi def link arcanistdiffBlank   Error
+hi def link arcanistdiffHeading Special
 hi def link arcanistdiffComment Comment


### PR DESCRIPTION
Some sites extend their arcanist diff templates to include additional
headings (e.g. "JIRA Issues:"). These could be added to local syntax
extensions, but it seems more natural to generalize this plugin's notion
of a "heading".

This is (intentionally) less specific than the previous approach and
carries with it the following shortcomings:

1. Arbitrary commit message text (e.g. /^Foo:/ could be matched).
2. Individual headings can no longer have their own highlighting.

... but those feel like worthwhile tradeoffs.