### PR TITLE
Use :setfiletype to set file types.

### DIFF
--- a/ftdetect/arcanist.vim
+++ b/ftdetect/arcanist.vim
@@ -4,5 +4,5 @@ else
     let s:tmp = '/tmp'
 endif
 
-execute "au BufNewFile,BufRead " . s:tmp . "/*/new-commit setlocal filetype=arcanistdiff"
-execute "au BufNewFile,BufRead .arc{config,lint,unit} setlocal filetype=json"
+execute "au BufNewFile,BufRead " . s:tmp . "/*/new-commit setfiletype arcanistdiff"
+au BufNewFile,BufRead .arc{config,lint,rc,unit} setfiletype json


### PR DESCRIPTION
Also, include `.arcrc` in the list of JSON configuration files and remove the
unnecessary `execute` call from this line.